### PR TITLE
fix/node: avoid handling 'ConnectionInfoRequest's until approved

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 env:
   global:
-    - Features=use-mock-crust
     - RUST_BACKTRACE=1
     - PATH=$PATH:$HOME/.cargo/bin
 branches:
@@ -21,7 +20,10 @@ before_script:
   - (which cargo-install-update && cargo install-update cargo-update) || cargo install cargo-update
   - (which cargo-prune && cargo install-update cargo-prune) || cargo install cargo-prune
   - if [ "${TRAVIS_RUST_VERSION}" = stable ]; then
-      (which rustfmt && cargo install-update rustfmt) || cargo install rustfmt;
+      rustfmt_vers=0.7.0;
+      if ! cargo fmt -- --version | grep -q $rustfmt_vers; then
+        cargo install rustfmt --vers=$rustfmt_vers --force;
+      fi
     elif [ "${TRAVIS_OS_NAME}" = linux ]; then
       clippy_vers=0.0.104;
       if ! cargo clippy --version | grep -q $clippy_vers; then


### PR DESCRIPTION
Also inserts the backlogged messages to the front of the message queue once approved, and fixes
rustfmt version in the Travis script to 0.7.0.