### PR TITLE
refactor/client: remove 'min_section_size' from Client API

### DIFF
--- a/examples/utils/example_client.rs
+++ b/examples/utils/example_client.rs
@@ -25,7 +25,6 @@ use rust_sodium::crypto;
 use std::sync::mpsc::{self, Receiver, TryRecvError};
 use std::thread;
 use std::time::{Duration, Instant};
-use super::MIN_SECTION_SIZE;
 
 const RESPONSE_TIMEOUT_SECS: u64 = 10;
 
@@ -55,8 +54,7 @@ impl ExampleClient {
         // Try to connect the client to the network. If it fails, it probably means
         // the network isn't fully formed yet, so we restart and try again.
         'outer: loop {
-            routing_client =
-                unwrap!(Client::new(sender.clone(), Some(full_id.clone()), MIN_SECTION_SIZE));
+            routing_client = unwrap!(Client::new(sender.clone(), Some(full_id.clone())));
 
             for event in receiver.iter() {
                 match event {

--- a/src/client.rs
+++ b/src/client.rs
@@ -73,10 +73,9 @@ impl Client {
     /// cryptographically secure and uses section consensus. The restriction for the client name
     /// exists to ensure that the client cannot choose its `ClientAuthority`.
     #[cfg(not(feature = "use-mock-crust"))]
-    pub fn new(event_sender: Sender<Event>,
-               keys: Option<FullId>,
-               min_section_size: usize)
-               -> Result<Client, RoutingError> {
+    pub fn new(event_sender: Sender<Event>, keys: Option<FullId>) -> Result<Client, RoutingError> {
+        // TODO - replace this hard-coded value
+        let min_section_size = 8;
         rust_sodium::init(); // enable shared global (i.e. safe to multithread now)
 
         // start the handler for routing with a restriction to become a full node

--- a/src/states/node.rs
+++ b/src/states/node.rs
@@ -1828,7 +1828,7 @@ impl Node {
             if rt_pfx.bit_count() >= prefix.bit_count() {
                 break;
             }
-            trace!("{:?} Splitting {:?} on section update.", self, rt_pfx);
+            info!("{:?} Splitting {:?} on section update.", self, rt_pfx);
             let _ = self.handle_section_split(rt_pfx, rt_pfx.lower_bound());
         }
         // Filter list of members to just those we don't know about:
@@ -1911,9 +1911,9 @@ impl Node {
         } else if old_prefix.bit_count() > new_prefix.bit_count() {
             result.add_event(Event::SectionMerge(new_prefix));
         }
-        trace!("{:?} Update on RoutingTableResponse completed. Prefixes: {:?}",
-               self,
-               self.peer_mgr.routing_table().prefixes());
+        info!("{:?} Update on RoutingTableResponse completed. Prefixes: {:?}",
+              self,
+              self.peer_mgr.routing_table().prefixes());
         let src = Authority::ManagedNode(*self.name());
         for member in members {
             if self.peer_mgr.routing_table().need_to_add(member.name()).is_ok() {
@@ -1951,9 +1951,9 @@ impl Node {
             self.disconnect_peer(&peer_id);
             info!("{:?} Dropped {:?} from the routing table.", self, name);
         }
-        trace!("{:?} Split completed. Prefixes: {:?}",
-               self,
-               self.peer_mgr.routing_table().prefixes());
+        info!("{:?} Split completed. Prefixes: {:?}",
+              self,
+              self.peer_mgr.routing_table().prefixes());
 
         self.merge_if_necessary();
 
@@ -1986,9 +1986,9 @@ impl Node {
             OwnMergeState::Completed { targets, merge_details } => {
                 // TODO - the event should maybe only fire once all new connections have been made?
                 result.add_event(Event::SectionMerge(merge_details.prefix));
-                trace!("{:?} Merge completed. Prefixes: {:?}",
-                       self,
-                       self.peer_mgr.routing_table().prefixes());
+                info!("{:?} Own section merge completed. Prefixes: {:?}",
+                      self,
+                      self.peer_mgr.routing_table().prefixes());
                 self.merge_if_necessary();
 
                 if merge_prefix == *self.peer_mgr.routing_table().our_prefix() {
@@ -2047,9 +2047,9 @@ impl Node {
                 debug!("{:?} - Failed to send connection info: {:?}", self, error);
             }
         }
-        trace!("{:?} Other merge completed. Prefixes: {:?}",
-               self,
-               self.peer_mgr.routing_table().prefixes());
+        info!("{:?} Other section merge completed. Prefixes: {:?}",
+              self,
+              self.peer_mgr.routing_table().prefixes());
         self.merge_if_necessary();
         self.send_section_list_signature(prefix, None);
         self.reset_rt_timer();

--- a/tests/ci.rs
+++ b/tests/ci.rs
@@ -123,7 +123,7 @@ struct TestClient {
 }
 
 impl TestClient {
-    fn new(index: usize, main_sender: Sender<TestEvent>, min_section_size: usize) -> Self {
+    fn new(index: usize, main_sender: Sender<TestEvent>) -> Self {
         let thread_name = format!("TestClient {} event sender", index);
         let (sender, joiner) = spawn_select_thread(index, main_sender, thread_name);
 
@@ -134,7 +134,7 @@ impl TestClient {
         TestClient {
             index: index,
             full_id: full_id.clone(),
-            client: unwrap!(Client::new(sender, Some(full_id), min_section_size)),
+            client: unwrap!(Client::new(sender, Some(full_id))),
             _thread_joiner: joiner,
         }
     }
@@ -299,7 +299,7 @@ fn core() {
 
     {
         // request and response
-        let client = TestClient::new(nodes.len(), event_sender.clone(), min_section_size);
+        let client = TestClient::new(nodes.len(), event_sender.clone());
         let data = gen_structured_data(client.full_id(), &mut rng);
         let message_id = MessageId::new();
 
@@ -344,7 +344,7 @@ fn core() {
     {
         // request to group authority
         let node_names = nodes.iter().map(|node| node.name()).collect_vec();
-        let client = TestClient::new(nodes.len(), event_sender.clone(), min_section_size);
+        let client = TestClient::new(nodes.len(), event_sender.clone());
         let data = gen_structured_data(client.full_id(), &mut rng);
         let mut close_group = closest_nodes(&node_names, client.name(), min_section_size);
 
@@ -381,7 +381,7 @@ fn core() {
     {
         // response from group authority
         let node_names = nodes.iter().map(|node| node.name()).collect_vec();
-        let client = TestClient::new(nodes.len(), event_sender.clone(), min_section_size);
+        let client = TestClient::new(nodes.len(), event_sender.clone());
         let data = gen_structured_data(client.full_id(), &mut rng);
         let mut close_group = closest_nodes(&node_names, client.name(), min_section_size);
 
@@ -493,7 +493,7 @@ fn core() {
 
     {
         // message from quorum - 1 section members
-        let client = TestClient::new(nodes.len(), event_sender.clone(), min_section_size);
+        let client = TestClient::new(nodes.len(), event_sender.clone());
         let data = gen_structured_data(client.full_id(), &mut rng);
 
         while let Ok(test_event) = recv_with_timeout(&mut nodes,
@@ -539,7 +539,7 @@ fn core() {
 
     {
         // message from more than quorum section members
-        let client = TestClient::new(nodes.len(), event_sender.clone(), min_section_size);
+        let client = TestClient::new(nodes.len(), event_sender.clone());
         let data = gen_structured_data(client.full_id(), &mut rng);
         let mut sent_ids = HashSet::new();
         let mut received_ids = HashSet::new();


### PR DESCRIPTION
Also increase log level for split/merge messages.